### PR TITLE
Fix unused using directive

### DIFF
--- a/include/magic_func/function.hpp
+++ b/include/magic_func/function.hpp
@@ -131,8 +131,8 @@ template <typename Callable, typename>
 Function<Return(Args...)>& Function<Return(Args...)>::operator =(
     Callable&& callable) {
   using T = std::remove_reference_t<Callable>;
-  func_ptr_ = reinterpret_func<TypeErasedFuncPtr>(&CallCallable<Callable>);
-  object_.StoreObject(std::forward<Callable>(callable));
+  func_ptr_ = reinterpret_func<TypeErasedFuncPtr>(&CallCallable<T>);
+  object_.StoreObject(std::forward<T>(callable));
   return *this;
 }
 


### PR DESCRIPTION
This would warn for unused-local-typdef otherwise with gcc 9.3.