### PR TITLE
Add alternative macro for MF_MakeFunction

### DIFF
--- a/include/magic_func/function.hpp
+++ b/include/magic_func/function.hpp
@@ -131,8 +131,8 @@ template <typename Callable, typename>
 Function<Return(Args...)>& Function<Return(Args...)>::operator =(
     Callable&& callable) {
   using T = std::remove_reference_t<Callable>;
-  func_ptr_ = reinterpret_func<TypeErasedFuncPtr>(&CallCallable<Callable>);
-  object_.StoreObject(std::forward<Callable>(callable));
+  func_ptr_ = reinterpret_func<TypeErasedFuncPtr>(&CallCallable<T>);
+  object_.StoreObject(std::forward<T>(callable));
   return *this;
 }
 

--- a/include/magic_func/make_function.h
+++ b/include/magic_func/make_function.h
@@ -42,6 +42,8 @@
 #ifndef MF_MakeFunction
 #define MF_MakeFunction(x, ...) \
     mf::make_function<decltype((x)), (x)>(__VA_ARGS__)
+#define MF_MakeFunctionNoArgs(x) \
+    mf::make_function<decltype((x)), (x)>()
 #endif
 
 namespace mf {


### PR DESCRIPTION
Since MF_MakeFunction cannot be called with less than 2 arguments in strict ISO C++11.
This PR also incorporates the previous one.